### PR TITLE
fix(docs): correct typos, grammar, and links across multiple chapters

### DIFF
--- a/chapters/getting_started.md
+++ b/chapters/getting_started.md
@@ -35,7 +35,7 @@ But Zipf's law isn't limited to words. It pops up in surprising places! Here are
 This can be seen in the following graph:
 
 ```{figure} ../figures/zipf/Zipf_30wiki_en_labels.png
-:name Zipfs Law visusalized
+:name Zipfs Law visualized
 
 ```
 
@@ -110,7 +110,7 @@ Our project will contain a few standard files that should be present in every re
 
 Some projects also include a `CONTRIBUTORS` or `AUTHORS` file that lists everyone who has contributed to the project, while others include that information in the `README` (we do this in Chapter [Git Advanced](https://se-up.github.io/RSE-UP/chapters/git_advanced.html)
 or make it a section in `CITATION`.
-These files are often called **boilerplate, meaning they are copied without change from one use to the next.
+These files are often called **boilerplate**, meaning they are copied without change from one use to the next.
 
 ### Organizing project content
 
@@ -119,9 +119,9 @@ Following {cite:p}`Nobl2009`, the directories in the repository's root are organ
 -   Runnable programs go in `bin/`
     (an old Unix abbreviation for "binary", meaning "not text").
     This will include both shell scripts,
-    e.g., `book_summary.sh` developed in Chapter [bash dvanced](https://se-up.github.io/RSE-UP/chapters/bash_advanced.html),,
+    e.g., `book_summary.sh` developed in Chapter [bash Advanced](https://se-up.github.io/RSE-UP/chapters/bash_advanced.html),,
     and Python programs,
-    e.g., `countwords.py`, developed in Chapter [building a CLI with python](https://se-up.github.io/RSE-UP/chapters/python_building_cli.html),).
+    e.g., `countwords.py`, developed in Chapter [Building Command-Line Tools with Python](https://se-up.github.io/RSE-UP/chapters/python_cli.html).
 
 -   Raw data goes in `data/`
     and is never modified after being stored.
@@ -134,7 +134,7 @@ Following {cite:p}`Nobl2009`, the directories in the repository's root are organ
     and everything else created using what's in `bin` and `data`.
     In this project,
     we'll describe exactly how `bin` and `data` are used
-    with `Makefile` created in Chapter **TODO** ref(automate).
+    with `Makefile` created in Chapter [Introduction to Make and Snakemake](https://se-up.github.io/RSE-UP/chapters/introduction/automation.html).
 
 -   Finally,
     documentation and manuscripts go in `docs/`.
@@ -147,7 +147,7 @@ This structure works well for many computational research projects and
 we encourage its use beyond just this book.
 We will add some more folders and files not directly addressed by {cite:p}`Nobl2009`
 when we talk about testing (Chapter on [Testing](https://se-up.github.io/RSE-UP/chapters/testing_programs.html)),
-provenance (Chapter ,
+provenance (Chapter [Tracking Provenance](https://se-up.github.io/RSE-UP/chapters/tracking_provenance.html)),
 and packaging (Chapter [Packaging](https://se-up.github.io/RSE-UP/chapters/python_packaging.html)).
 
 
@@ -184,8 +184,8 @@ Now that our project structure is set up, our data is downloaded, we are ready t
 ### Getting ready 
 
 Make sure you've downloaded the required data files
-(following Section [downloading the data ](https://se-up.github.io/RSE-UP/chapters/getting_started.html#downloading-the-data)
-and installed the required software ([as described here](https://se-up.github.io/RSE-UP/exercises/install.html#installing-the-software)) before progressing to the next chapter.
+(following Section [downloading the data ](https://se-up.github.io/RSE-UP/chapters/getting_started.html#downloading-the-data))
+and installed the required software ([as described here](https://se-up.github.io/RSE-UP/chapters/install.html)) before progressing to the next chapter.
 
 ## Key Points
 

--- a/chapters/license.md
+++ b/chapters/license.md
@@ -167,7 +167,7 @@ The Appache License provides a balance between openness and legal protection. Li
 
 #### GNU General Public License (GPL):
 
-The GNU GPL is a strong copyleft license designed to ensure that software remains free and open for all users. **Any** derivative work or modified version of the software **must** be licensed under the smae terms, which ensures that freedom to use, modify, and share is preserved even throughout the software's evolution over time. The GNU GPL also requires that source code is publically available whenever the software - or derivatives thereof - are distributed. Thus, creating a culture of openness and collaboration in the userbase. The license is ideal for projects where the goal is to maintain a fully open ecosystem, but its strict requirements may limit compatibility to non-GPL software.
+The GNU GPL is a strong copyleft license designed to ensure that software remains free and open for all users. **Any** derivative work or modified version of the software **must** be licensed under the same terms, which ensures that freedom to use, modify, and share is preserved even throughout the software's evolution over time. The GNU GPL also requires that source code is publically available whenever the software - or derivatives thereof - are distributed. Thus, creating a culture of openness and collaboration in the userbase. The license is ideal for projects where the goal is to maintain a fully open ecosystem, but its strict requirements may limit compatibility to non-GPL software.
 
 - Copyleft license that ensures derivative works are also licensed under the GPL.
 
@@ -194,9 +194,9 @@ Each license type balances openness and control differently:
 
 ## CC0 (Public Domain Dedication)
 
-The CC0 license specifically waives all rights and deidcates the work to the public domain. This allows **anyone** to freely use, modify, and distribute the work withoout asking for permission or having to give any credit. CC0 is the most permissive of the CC licenses and is often used for datasets and resources intended for unrestricted public access. The CC0 combines exactly 0 (hence the name) of the above-mentioned basic elements of the CC licenses.
+The CC0 license specifically waives all rights and dedicates the work to the public domain. This allows **anyone** to freely use, modify, and distribute the work without asking for permission or having to give any credit. CC0 is the most permissive of the CC licenses and is often used for datasets and resources intended for unrestricted public access. The CC0 combines exactly 0 (hence the name) of the above-mentioned basic elements of the CC licenses.
 
-- No rights reserved: completly free to uses, even commercially.
+- No rights reserved: completely free to uses, even commercially.
 - No attribution required.
 - Ideal for datasets, reference materials, and public domain works.
 - Not recommended for software (consider using an open-source license instead)
@@ -221,7 +221,7 @@ This license allows for adaptations and commercial use of the work, so long as a
 
 ## CC BY-ND (Attribution-NoDerivatives)
 
-CC BY-ND is more restrictive. It permits redistribution for commercial and non-commercial use, as long as the work remains **unchanged** and the creator is properly credited. **No* derivatives are alloed of the work, thus making this license type useful when creators want their work to be shared widely, but without any modification.
+CC BY-ND is more restrictive. It permits redistribution for commercial and non-commercial use, as long as the work remains **unchanged** and the creator is properly credited. **No* derivatives are allowed of the work, thus making this license type useful when creators want their work to be shared widely, but without any modification.
 
 - Allows redistribution with proper attribution.
 - No modifications or adaptations are permitted.
@@ -231,7 +231,7 @@ CC BY-ND is more restrictive. It permits redistribution for commercial and non-c
 
 ## CC BY-NC (Attribution-NonCommercial)
 
-This license lets other remix, adapt, and build upon the work. However it restricts the use of the work and its derivatives to non-commercial use only. It also requires proper attribution. The license is widely used in academtic and non-profit contexts, where public sharing is encouraged but commercial exploitation should be restricted.
+This license lets other remix, adapt, and build upon the work. However it restricts the use of the work and its derivatives to non-commercial use only. It also requires proper attribution. The license is widely used in academic and non-profit contexts, where public sharing is encouraged but commercial exploitation should be restricted.
 
 - Permits reuse and modification, but only for non-commercial purposes.
 - Requires attribution to the original creator.
@@ -243,12 +243,12 @@ The CC BY-NC-SA license combines the non-commercial and share-alike clauses. It 
 
 - Non-commercial use only, with attribution.
 - Derivative works must use the same license.
-- Encourages non-comemrcial collaboration and content sharing.
+- Encourages non-commercial collaboration and content sharing.
 - Common in academic and educational resources.
 
 ## CC BY-NC-ND (Attribution-NonCommercial-NoDerivatives)
 
-This license is the most restrictive of the CC licenses. It allows the user to download and share the work with proper credit, but the users are not allowed to alter the work in any way, nor are they allowed to exploit the work commercially. It is best for creators who want their work circulated as-is, but do not with for it to be changed or monetized.
+This license is the most restrictive of the CC licenses. It allows the user to download and share the work with proper credit, but the users are not allowed to alter the work in any way, nor are they allowed to exploit the work commercially. It is best for creators who want their work circulated as-is, but do not wish for it to be changed or monetized.
 
 - Redistribution allowed with attribution.
 - No commercial use or derivative works are allowed.
@@ -259,7 +259,7 @@ All CC licenses can be found [here](https://creativecommons.org/licenses/), incl
 
 ### Which License should you choose? 
 
-Choosing the most suitable license for your project involves serveral important considerations.
+Choosing the most suitable license for your project involves several important considerations.
 First, it's essential to decide whether the work should be licensed at all, as some projects may be intended for private or restricted use only.
 If the content includes source code, it's important to determine whether open-source licensing is appropriate, and if so whether you want to require that derivative works also share the source code for their adaptations.
 Additionally, licensing may address patent rights. This may be crucial for any projects that includes state-of-the-art software or algorithms.

--- a/chapters/welcome.md
+++ b/chapters/welcome.md
@@ -37,7 +37,7 @@ This course is designed for students researchers who are already using Python fo
 but you should already be comfortable doing things like reading data from files
 and writing loops, conditionals, and functions.
 
-To make sure that your Python skills are at the expected level, you can either try our [Python refresher](https://se-up.github.io/RSE-UP/exercises/python_refresh.html) or, if you are already experienced with other programming languages, you can also checkout out the python tutorials on [exercism.org](https://exercism.org/) to get up to speed with the python syntax. 
+To make sure that your Python skills are at the expected level, you can either try our [Python refresher](https://se-up.github.io/RSE-UP/exercises/python_refresher.html) or, if you are already experienced with other programming languages, you can also check out the python tutorials on [exercism.org](https://exercism.org/) to get up to speed with the python syntax. 
 
 
 ## The Big Picture
@@ -132,12 +132,12 @@ we will show you how to do the following:
 -   Use the Unix shell to efficiently manage your data and code.
 -   Write Python programs that can be used on the command line.
 -   Use Git and GitHub to track and share your work.
--   Work productively in a small team where -upveryone is welcome.
+-   Work productively in a small team where everyone is welcome.
 -   Use Make to automate complex workflows.
 -   Enable users to configure your software without modifying it directly.
 -   Test your software and know which parts have not yet been tested.
 -   Find, handle, and fix errors in your code.
--   Publish your code and research in open a-upd reproducible ways.
+-   Publish your code and research in open and reproducible ways.
 -   Create Python packages that can be installed in standard ways.
 
 
@@ -159,7 +159,7 @@ Possible solutions to the exercises are provided in the [Appendix](https://se-u
 
 ## Contributing and Re-Use
 
-The source for the book can be found at the ['RSE-UP' GitHub repository](https://se-up.github.io/RSE-UP) and any corrections, additions, or contributions are very welcome. 
+The source for the book can be found at the ['RSE-UP' GitHub repository](https://github.com/SE-UP/RSE-UP) and any corrections, additions, or contributions are very welcome. 
 Everyone whose work is included will be credited in the acknowledgments.
 Check out our [contributing guidelines](https://github.com/se-up/RSE-UP/blob/main/CONTRIBUTION.md)
 as well as our [Code of Conduct](https://github.com/se-up/RSE-UP/blob/main/CODE_OF_CONDUCT.md) for more information on how to contribute.

--- a/exercises/python_refresher.ipynb
+++ b/exercises/python_refresher.ipynb
@@ -114,7 +114,7 @@
     ">cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id \\\n",
     ">est laborum.\"\n",
     "\n",
-    "To check if a character c is an alphabetic character, you can call the isalpha() function on it: `c.isalpha()`. It will return `True` or `False`.\n",
+    "To check if a character c is an alphabetic character, you can call the `isalpha()` function on it: `c.isalpha()`. It will return `True` or `False`.\n",
     "The output of your program should report the longest word and its length, like this:\n",
     "`The longest word in the text is \"reprehenderit\" (13 characters)`."
    ]


### PR DESCRIPTION
Corrects typos, grammar, and links across multiple chapters. The changes span across getting_started.md, license.md, welcome.md, and python_refresher.ipynb. Tested by building successfully.